### PR TITLE
Format levels of categorical variables in get_regression_table()

### DIFF
--- a/R/regression_functions.R
+++ b/R/regression_functions.R
@@ -47,6 +47,7 @@ get_regression_table <- function(model, digits = 3, print = FALSE) {
   explanatory_variable <- formula(model) %>%
     rhs() %>%
     all.vars()
+  cat_explanatory_variable <- names(model[["xlevels"]])
 
   # Create output tibble
   regression_table <- model %>%
@@ -58,7 +59,7 @@ get_regression_table <- function(model, digits = 3, print = FALSE) {
     rename(
       lower_ci = conf_low,
       upper_ci = conf_high
-    )
+    ) %>% mutate(term = extract_cat_names(term, cat_explanatory_variable))
 
   # Transform to markdown
   if (print) {
@@ -312,6 +313,31 @@ get_regression_summaries <-
     return(regression_summaries)
   }
 
+
+# Extract explanatory categorical variable levels ----
+extract_cat_names <- function(term, cat_names) {
+  # if none of the x variables are categorical, do nothing
+  if (length(cat_names) > 0){
+    # the xlevels should only be matched at the beginning of the term
+    matches <-
+      as.character(stringr::str_match(term, paste0("^",cat_names, collapse = "|")))
+    not_matched <- c(1,which(is.na(matches)))
+    # force intercept term to always be in the not_matched group
+    
+    
+    if (length(matches) > 0) {
+      matches <-
+        paste0(matches, ": ", stringr::str_sub(term, nchar(matches) + 1, nchar(term)))
+      matches[not_matched] <- term[not_matched]
+      return(matches)
+    } else{
+      return(term)
+    }
+  } else {
+    return(term)
+  }
+  
+}
 
 
 

--- a/man/get_regression_table.Rd
+++ b/man/get_regression_table.Rd
@@ -4,7 +4,12 @@
 \alias{get_regression_table}
 \title{Get regression table}
 \usage{
-get_regression_table(model, digits = 3, print = FALSE)
+get_regression_table(
+  model,
+  digits = 3,
+  print = FALSE,
+  default_categorical_levels = FALSE
+)
 }
 \arguments{
 \item{model}{an \code{lm()} model object}
@@ -12,6 +17,11 @@ get_regression_table(model, digits = 3, print = FALSE)
 \item{digits}{number of digits precision in output table}
 
 \item{print}{If TRUE, return in print format suitable for R Markdown}
+
+\item{default_categorical_levels}{If TRUE, do not change the non-baseline
+categorical variables in the term column. Otherwise non-baseline 
+categorical variables will be displayed in the format 
+"categorical_variable_name: level_name"}
 }
 \value{
 A tibble-formatted regression table along with lower and upper end

--- a/tests/testthat/test-get_regression_functions.R
+++ b/tests/testthat/test-get_regression_functions.R
@@ -101,3 +101,27 @@ test_that("README code works", {
       get_regression_summaries(digits = 5, print = TRUE)
   )
 })
+
+
+test_that("pretty printing xlevels used in `get_regression_table` 
+          does not give unexpected outputs", {
+  terms <-
+    c("intercept",
+      "aaaa",
+      "babab",
+      "c_c-x",
+      "xx-xx",
+      "not intercept and not categorical")
+  xlevels <- c("a", "b", "i", "c", "x")
+  expect_equal(
+    moderndive:::extract_cat_names(terms, xlevels),
+    c(
+      "intercept",
+      "a: aaa",
+      "b: abab",
+      "c: _c-x",
+      "x: x-xx",
+      "not intercept and not categorical"
+    )
+  )
+})

--- a/tests/testthat/test-get_regression_functions.R
+++ b/tests/testthat/test-get_regression_functions.R
@@ -57,6 +57,15 @@ test_that("function inputs are valid", {
   expect_error(
     get_regression_points(model = mpg_cyl, ID = 6)
   )
+  
+  # Check default_categorical_levels
+  expect_silent(
+    get_regression_table(model = mpg_cyl, digits = 5, print = FALSE, default_categorical_levels = TRUE)
+  )
+  
+  expect_error(
+    get_regression_table(model = mpg_cyl, digits = 5, print = FALSE, default_categorical_levels = "yes pls")
+  )
 })
 
 
@@ -114,7 +123,7 @@ test_that("pretty printing xlevels used in `get_regression_table`
       "not intercept and not categorical")
   xlevels <- c("a", "b", "i", "c", "x")
   expect_equal(
-    moderndive:::extract_cat_names(terms, xlevels),
+    moderndive:::extract_cat_names(terms, xlevels, FALSE),
     c(
       "intercept",
       "a: aaa",
@@ -125,3 +134,19 @@ test_that("pretty printing xlevels used in `get_regression_table`
     )
   )
 })
+
+test_that(
+  "we display modified non-baseline levels of categorical variables by default, but allow users to use the default R behavior",
+  {
+    expect_equal(
+      get_regression_table(mpg_cyl, default_categorical_levels = TRUE) %>% pull(term) %>% .[c(-1)],
+      names(mpg_cyl$coefficients)[c(-1)]
+    )
+    
+    mpg_model <- lm(mpg ~ hp, data = mtcars)
+    expect_equal(
+      get_regression_table(mpg_model, default_categorical_levels = FALSE) %>% pull(term) %>% .[c(-1)],
+      names(mpg_model$coefficients)[c(-1)]
+    )
+  }
+)


### PR DESCRIPTION
The goal of this PR is to display levels of categorical explanatory variables in a more readable format in the `get_regression_table` data frame. It only modifies the `term` column of the `get_regression_table` data frame for categorical variables. Here is an example of the modified output:

``` r
library(dplyr)
library(tibble)
library(moderndive)

# Modify mtcars and run two lm() models
mtcars <- mtcars %>%
  rownames_to_column(var = "automobile") %>%
  mutate(cyl = as.factor(cyl))

mpg_cyl <- lm(mpg ~ cyl, data = mtcars)
get_regression_table(mpg_cyl)
#> # A tibble: 3 x 7
#>   term      estimate std_error statistic p_value lower_ci upper_ci
#>   <chr>        <dbl>     <dbl>     <dbl>   <dbl>    <dbl>    <dbl>
#> 1 intercept    26.7      0.972     27.4        0     24.7    28.7 
#> 2 cyl: 6       -6.92     1.56      -4.44       0    -10.1    -3.73
#> 3 cyl: 8      -11.6      1.30      -8.90       0    -14.2    -8.91
```

This is in comparison to the standard output:
```r
#> # A tibble: 3 x 7
#>   term      estimate std_error statistic p_value lower_ci upper_ci
#>   <chr>        <dbl>     <dbl>     <dbl>   <dbl>    <dbl>    <dbl>
#> 1 intercept    26.7      0.972     27.4        0     24.7    28.7 
#> 2 cyl6       -6.92     1.56      -4.44       0    -10.1    -3.73
#> 3 cyl8      -11.6      1.30      -8.90       0    -14.2    -8.91
````

<sup>Created on 2021-02-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This is a rather small aesthetic change, but I think it could help R learners more easily interpret the regression table output. Another option would be to include this as an argument for `get_regression_table` with a default value of `FALSE`. 