### PR TITLE
Fix formatting category levels in get_regression_tables failing for in-line factors

### DIFF
--- a/R/regression_functions.R
+++ b/R/regression_functions.R
@@ -320,6 +320,13 @@ get_regression_summaries <-
 
 
 # Extract explanatory categorical variable levels ----
+
+# helper function to escape regex characters from a variable name
+remove_re_char <- function(string){
+  # taken from the `escapeRegex` function in the Hmisc package
+  gsub("([.|()\\^{}+$*?]|\\[|\\])", "\\\\\\1", string)
+}
+
 extract_cat_names <- function(term, cat_names, default_categorical_levels) {
     if ((!default_categorical_levels) & (length(cat_names) > 0)) {
       # if none of the x variables are categorical, do nothing
@@ -327,9 +334,14 @@ extract_cat_names <- function(term, cat_names, default_categorical_levels) {
       # if at least one of the x variables are categorical AND the user
       # does not want the default categorical levels
       
+      # we need to handle the case where a factor is defined within the regression
+      # equation
+      cat_names <- remove_re_char(cat_names)
+      cat_names <- cat_names[order(nchar(cat_names), decreasing = T)]
+      
       # the xlevels should only be matched at the beginning of the term
       matches <-
-        as.character(stringr::str_match(term, paste0("^", cat_names, collapse = "|")))
+        as.character(stringr::str_extract(term, paste0("(", "^", cat_names, ")", collapse = "|")))
       not_matched <- c(1, which(is.na(matches)))
       # force intercept term to always be in the not_matched group
       if (length(matches) > 0) {

--- a/tests/testthat/test-get_regression_functions.R
+++ b/tests/testthat/test-get_regression_functions.R
@@ -120,8 +120,9 @@ test_that("pretty printing xlevels used in `get_regression_table`
       "babab",
       "c_c-x",
       "xx-xx",
-      "not intercept and not categorical")
-  xlevels <- c("a", "b", "i", "c", "x")
+      "not intercept and not categorical",
+      "as.factor(cyl)6")
+  xlevels <- c("a", "b", "i", "c", "x", "as.factor(cyl)")
   expect_equal(
     moderndive:::extract_cat_names(terms, xlevels, FALSE),
     c(
@@ -130,7 +131,8 @@ test_that("pretty printing xlevels used in `get_regression_table`
       "b: abab",
       "c: _c-x",
       "x: x-xx",
-      "not intercept and not categorical"
+      "not intercept and not categorical",
+      "as.factor(cyl): 6"
     )
   )
 })

--- a/tests/testthat/test-get_regression_functions.R
+++ b/tests/testthat/test-get_regression_functions.R
@@ -121,8 +121,9 @@ test_that("pretty printing xlevels used in `get_regression_table`
       "c_c-x",
       "xx-xx",
       "not intercept and not categorical",
-      "as.factor(cyl)6")
-  xlevels <- c("a", "b", "i", "c", "x", "as.factor(cyl)")
+      "as.factor(cyl)6",
+      "factor(cyl)6")
+  xlevels <- c("a", "b", "i", "c", "x", "as.factor(cyl)", "factor(cyl)")
   expect_equal(
     moderndive:::extract_cat_names(terms, xlevels, FALSE),
     c(
@@ -132,7 +133,8 @@ test_that("pretty printing xlevels used in `get_regression_table`
       "c: _c-x",
       "x: x-xx",
       "not intercept and not categorical",
-      "as.factor(cyl): 6"
+      "as.factor(cyl): 6",
+      "factor(cyl): 6"
     )
   )
 })


### PR DESCRIPTION
Hello, I realized that the PR I wrote (#102) fails when a factor is defined in-line in a regression equation. For example:

``` r
library(dplyr)
library(moderndive)

mpg_cyl <- lm(mpg ~ as.factor(cyl), data = mtcars)
# this gives an error
get_regression_table(mpg_cyl)
#> Error: Problem with `mutate()` input `term`.
#> x Input `term` can't be recycled to size 3.
#> ℹ Input `term` is `extract_cat_names(term, cat_explanatory_variable, default_categorical_levels)`.
#> ℹ Input `term` must be size 3 or 1, not 6.
```

This is because the variable name `as.factor(cyl)` contains regex escape characters so the `extract_cat_names` function throws an error. I've come up with a solution in the form of this PR to handle this case to give the following output:

``` r
library(dplyr)
library(moderndive)

mpg_cyl <- lm(mpg ~ as.factor(cyl), data = mtcars)
get_regression_table(mpg_cyl)

#> # A tibble: 3 x 7
#>   term              estimate std_error statistic p_value lower_ci upper_ci
#>   <chr>                <dbl>     <dbl>     <dbl>   <dbl>    <dbl>    <dbl>
#> 1 intercept            26.7      0.972     27.4        0     24.7    28.7 
#> 2 as.factor(cyl): 6    -6.92     1.56      -4.44       0    -10.1    -3.73
#> 3 as.factor(cyl): 8   -11.6      1.30      -8.90       0    -14.2    -8.91
```

I've also added an additional test case to make sure we can handle in-line factor definitions properly. Please let me know if you have any other ideas of potential gotchas.