### PR TITLE
Better navigating reference index objects by grouping them (for website)

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,33 @@
+url: "moderndive.github.io/moderndive/"
+
+reference:
+- title: Functions
+  contents:
+  - '`geom_categorical_model`'
+  - '`geom_parallel_slopes`'
+  - '`get_correlation`'
+  - '`get_regression_points`'
+  - '`get_regression_summaries`'
+  - '`get_regression_table`'
+  - '`gg_parallel_slopes`'
+- title: Datasets
+  contents:
+  - '`DD_vs_SB`'
+  - '`MA_schools`'
+  - '`bowl`'
+  - '`bowl_sample_1`'
+  - '`bowl_samples`'
+  - '`evals`'
+  - '`movies_sample`'
+  - '`mythbusters_yawn`'
+  - '`orig_pennies_sample`'
+  - '`pennies`'
+  - '`pennies_resamples`'
+  - '`pennies_sample`'
+  - '`promotions`'
+  - '`promotions_shuffled`'
+  - '`tactile_prop_red`'
+  - '`house_prices`'
+- title: Misc
+  contents:
+  - '`moderndive`'


### PR DESCRIPTION
Part of JOSE review https://github.com/openjournals/jose-reviews/issues/115

With all the datasets and only a  few functions, it was a bit difficult to navigate the pkgdown reference index list. So this grouping should make it easier to navigate. Generated using `pkgdown::template_reference()`.

Depends on #105.