### PR TITLE
Removing 'judgemental' language from text

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -98,7 +98,7 @@ knitr::include_graphics("man/figures/plot-example-1.png")
 
 #### 1. Print markdown friendly tables
 
-Want to output cleanly formatted tables in an R Markdown document? Just add `print = TRUE` to any of the three `get_regression_*()` functions.
+Want to output cleanly formatted tables in an R Markdown document? Add `print = TRUE` to any of the three `get_regression_*()` functions.
 
 ```{r}
 get_regression_table(score_model, print = TRUE)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ we highlight four functions in particular as covered there.
 
 We also mention the `geom_parallel_slopes()` function as **\#4**.
 
-#### 1\. Get regression tables
+#### 1. Get regression tables
 
 Get a tidy regression table **with** confidence intervals:
 
@@ -78,7 +78,7 @@ get_regression_table(score_model, conf.level = 0.99)
     ## 1 intercept    4.46      0.127     35.2    0        4.13     4.79 
     ## 2 age         -0.006     0.003     -2.31   0.021   -0.013    0.001
 
-#### 2\. Get fitted/predicted values and residuals
+#### 2. Get fitted/predicted values and residuals
 
 Get information on each point/observation in your regression, including
 fitted/predicted values & residuals (e.g. `score_hat` and `residual`),
@@ -103,7 +103,7 @@ get_regression_points(score_model)
     ## 10    10   4.5    40      4.22    0.276
     ## # … with 453 more rows
 
-#### 3\. Get regression fit summaries
+#### 3. Get regression fit summaries
 
 Get all the scalar summaries of a regression fit included in
 `summary(score_model)` along with the mean-squared error and root
@@ -118,7 +118,7 @@ get_regression_summaries(score_model)
     ##       <dbl>         <dbl> <dbl> <dbl> <dbl>     <dbl>   <dbl> <dbl> <dbl>
     ## 1     0.011         0.009 0.292 0.540 0.541      5.34   0.021     1   463
 
-#### 4\. Plot parallel slopes models
+#### 4. Plot parallel slopes models
 
 Plot parallel slopes regression models involving one categorical and one
 numerical explanatory/predictor variable (something you cannot do using
@@ -135,29 +135,28 @@ ggplot(evals, aes(x = age, y = score, color = ethnicity)) +
 
 ## Other features
 
-#### 1\. Print markdown friendly tables
+#### 1. Print markdown friendly tables
 
-Want to output cleanly formatted tables in an R Markdown document? Just
-add `print = TRUE` to any of the three `get_regression_*()` functions.
+Want to output cleanly formatted tables in an R Markdown document? Add
+`print = TRUE` to any of the three `get_regression_*()` functions.
 
 ``` r
 get_regression_table(score_model, print = TRUE)
 ```
 
 | term      | estimate | std\_error | statistic | p\_value | lower\_ci | upper\_ci |
-| :-------- | -------: | ---------: | --------: | -------: | --------: | --------: |
+|:----------|---------:|-----------:|----------:|---------:|----------:|----------:|
 | intercept |    4.462 |      0.127 |    35.195 |    0.000 |     4.213 |     4.711 |
-| age       |  \-0.006 |      0.003 |   \-2.311 |    0.021 |   \-0.011 |   \-0.001 |
+| age       |   -0.006 |      0.003 |    -2.311 |    0.021 |    -0.011 |    -0.001 |
 
-#### 2\. Predictions on new data
+#### 2. Predictions on new data
 
 Want to apply your fitted model on new data to make predictions? No
-problem\! Include a `newdata` data frame argument to
+problem! Include a `newdata` data frame argument to
 `get_regression_points()`.
 
-For example, the Kaggle.com practice competition [House Prices: Advanced
-Regression
-Techniques](https://www.kaggle.com/c/house-prices-advanced-regression-techniques)
+For example, the Kaggle.com practice competition
+<a href="https://www.kaggle.com/c/house-prices-advanced-regression-techniques" target="_blank">House Prices: Advanced Regression Techniques</a>
 requires you to fit/train a model to the provided `train.csv` training
 set to make predictions of house prices in the provided `test.csv` test
 set. The following code performs these steps and outputs the predictions
@@ -189,7 +188,7 @@ error” leaderboard score of 0.42918.
 ## The Details
 
 The three `get_regression` functions are wrappers of functions from the
-[`broom`](https://CRAN.R-project.org/package=broom/vignettes/broom.html)
+<a href="https://CRAN.R-project.org/package=broom/vignettes/broom.html" target="_blank"><code>broom</code></a>
 package for converting statistical analysis objects into tidy tibbles
 along with a few added tweaks:
 
@@ -199,19 +198,17 @@ along with a few added tweaks:
 
 Why did we create these wrappers?
 
-  - The `broom` package function names `tidy()`, `augment()`, and
+-   The `broom` package function names `tidy()`, `augment()`, and
     `glance()` don’t mean anything to intro stats students, where as the
     `moderndive` package function names `get_regression_table()`,
     `get_regression_points()`, and `get_regression_summaries()` are more
     intuitive.
-  - The default column/variable names in the outputs of the above 3
+-   The default column/variable names in the outputs of the above 3
     functions are a little daunting for intro stats students to
     interpret. We cut out some of them and renamed many of them with
     more intuitive names. For example, compare the outputs of the
     `get_regression_points()` wrapper function and the parent
     `broom::augment()` function.
-
-<!-- end list -->
 
 ``` r
 get_regression_points(score_model)
@@ -252,7 +249,7 @@ augment(score_model)
     ## 10   4.5    40    4.22  0.276  0.00374  0.542 0.000488       0.510
     ## # … with 453 more rows
 
------
+------------------------------------------------------------------------
 
 Please note that this project is released with a [Contributor Code of
 Conduct](CONDUCT.md). By participating in this project you agree to

--- a/vignettes/paper.md
+++ b/vignettes/paper.md
@@ -136,7 +136,7 @@ Here are 5 common student questions we've heard over the years in our introducto
 
 ## Regression analysis using `moderndive`
 
-To address these questions, we've included three functions in the `moderndive` package that take a fitted model object as input and return the same information as `summary.lm()`, but output them in tidyverse-friendly format [@tidyverse2019]. As we'll see later, while these three functions are merely wrappers to existing functions in the `broom` package for converting statistical objects into tidy tibbles, we modified them with the introductory statistics student in mind [@R-broom].
+To address these questions, we've included three functions in the `moderndive` package that take a fitted model object as input and return the same information as `summary.lm()`, but output them in tidyverse-friendly format [@tidyverse2019]. As we'll see later, while these three functions are thin wrappers to existing functions in the `broom` package for converting statistical objects into tidy tibbles, we modified them with the introductory statistics student in mind [@R-broom].
 
 1. Get a tidy regression table **with confidence intervals**:
     
@@ -203,7 +203,7 @@ ggplot(evals, aes(x = age, y = score, color = ethnicity)) +
 
 However, many introductory statistics courses start with the easier to teach "common slope, different intercepts" regression model, also known as the *parallel slopes* model. However, no argument to plot such models exists within `geom_smooth()`.
 
-[Evgeni Chasnovski](https://github.com/echasnovski){target="_blank"} thus wrote a custom `geom_` extension to `ggplot2` called `geom_parallel_slopes()`; this extension is included in the `moderndive` package. Much like `geom_smooth()` from the `ggplot2` package, you merely add a `geom_parallel_slopes()` layer to the code, resulting in \autoref{fig:parallel-slopes-model}.
+[Evgeni Chasnovski](https://github.com/echasnovski){target="_blank"} thus wrote a custom `geom_` extension to `ggplot2` called `geom_parallel_slopes()`; this extension is included in the `moderndive` package. Much like `geom_smooth()` from the `ggplot2` package, you add `geom_parallel_slopes()` as another layer to the code, resulting in \autoref{fig:parallel-slopes-model}.
 
 
 ```r
@@ -264,7 +264,7 @@ get_regression_table(score_model)
 ## 2 age         -0.006     0.003     -2.31   0.021   -0.011   -0.001
 ```
 
-Observe how the p-value stars are omitted and confidence intervals for the point estimates of all regression parameters are included by default. By including them in the output, we can easily emphasize to students that they "surround" the point estimates in the `estimate` column. Note the confidence level is defaulted to 95%; this default can be changed using the `conf.level` argument: 
+Observe how the p-value stars are omitted and confidence intervals for the point estimates of all regression parameters are included by default. By including them in the output, we can then emphasize to students that they "surround" the point estimates in the `estimate` column. Note the confidence level is defaulted to 95%; this default can be changed using the `conf.level` argument: 
 
 
 ```r
@@ -283,7 +283,7 @@ The second common student question:
 
 > "How do we extract the values in the regression table?"
 
-While one might argue that extracting the intercept and slope coefficients can be simply done using `coefficients(score_model)`, what about the standard errors? For example, a Google query of "_how do I extract standard errors from lm in R_" yielded results from [the R mailing list](https://stat.ethz.ch/pipermail/r-help/2008-April/160538.html){target="_blank"} and from [Cross Validated](https://stats.stackexchange.com/questions/27511/extract-standard-errors-of-coefficient-linear-regression-r){target="_blank"} suggesting we run:
+While one might argue that extracting the intercept and slope coefficients can be "simply" done using `coefficients(score_model)`, what about the standard errors? For example, a Google query of "_how do I extract standard errors from lm in R_" yielded results from [the R mailing list](https://stat.ethz.ch/pipermail/r-help/2008-April/160538.html){target="_blank"} and from [Cross Validated](https://stats.stackexchange.com/questions/27511/extract-standard-errors-of-coefficient-linear-regression-r){target="_blank"} suggesting we run:
 
 
 ```r
@@ -292,7 +292,7 @@ sqrt(diag(vcov(score_model)))
 ## 0.126778499 0.002569157
 ```
 
-We argue that this task shouldn't be this hard, especially in an introductory statistics setting. To rectify this, the three `get_regression_*` functions  all return data frames in the tidyverse-style tibble (tidy table) format [@R-tibble]. Therefore you can easily extract columns using the `pull()` function from the `dplyr` package [@R-dplyr]:
+We argue that this task shouldn't be this hard, especially in an introductory statistics setting. To rectify this, the three `get_regression_*` functions  all return data frames in the tidyverse-style tibble (tidy table) format [@R-tibble]. Therefore you can extract columns using the `pull()` function from the `dplyr` package [@R-dplyr]:
 
 
 
@@ -381,7 +381,7 @@ score_model_points
 ## 10    10   4.5    40      4.22    0.276
 ```
 
-Observe that the original outcome variable `score` and explanatory/predictor variable `age` are now supplemented with the fitted/predicted values `score_hat` and `residual` columns. By putting the fitted values, predicted values, and residuals next to the original data, we argue that the computation of these values is less opaque. For example, instructors can easily emphasize how all values in the first row of output are computed.
+Observe that the original outcome variable `score` and explanatory/predictor variable `age` are now supplemented with the fitted/predicted values `score_hat` and `residual` columns. By putting the fitted values, predicted values, and residuals next to the original data, we argue that the computation of these values is less opaque. For example, instructors can emphasize how all values in the first row of output are computed.
 
 Furthermore, recall that since all outputs in the `moderndive` package are tibble data frames, custom residual analysis plots can be created instead of relying on the default plots yielded by `plot.lm()`. For example, we can check for the normality of residuals using the histogram of residuals shown in \autoref{fig:residuals-1}.
 
@@ -667,7 +667,7 @@ While many students will inevitably find these results depressing, in our opinio
 
 ## Three wrappers to `broom` functions {#broom-wrappers}
 
-As we mentioned earlier, the three `get_regression_*` functions are merely wrappers of functions from the `broom` package for converting statistical analysis objects into tidy tibbles along with a few added tweaks, but with the introductory statistics student in mind [@R-broom]:
+As we mentioned earlier, the three `get_regression_*` functions are wrappers of functions from the `broom` package for converting statistical analysis objects into tidy tibbles along with a few added tweaks, but with the introductory statistics student in mind [@R-broom]:
 
 1. `get_regression_table()` is a wrapper for `broom::tidy()`.
 1. `get_regression_points()` is a wrapper for `broom::augment()`.

--- a/vignettes/why-moderndive.Rmd
+++ b/vignettes/why-moderndive.Rmd
@@ -161,7 +161,7 @@ Here are 5 common student questions we've heard over the years in our introducto
 
 ## Regression analysis using `moderndive`
 
-To address these questions, we've included three functions in the `moderndive` package that take a fitted model object as input and return the same information as `summary.lm()`, but output them in tidyverse-friendly format [@tidyverse2019]. As we'll see later, while these three functions are merely wrappers to existing functions in the `broom` package for converting statistical objects into tidy tibbles, we modified them with the introductory statistics student in mind [@R-broom].
+To address these questions, we've included three functions in the `moderndive` package that take a fitted model object as input and return the same information as `summary.lm()`, but output them in tidyverse-friendly format [@tidyverse2019]. As we'll see later, while these three functions are thin wrappers to existing functions in the `broom` package for converting statistical objects into tidy tibbles, we modified them with the introductory statistics student in mind [@R-broom].
 
 1. Get a tidy regression table **with confidence intervals**:
     ```{r}
@@ -191,7 +191,7 @@ ggplot(evals, aes(x = age, y = score, color = ethnicity)) +
 
 However, many introductory statistics courses start with the easier to teach "common slope, different intercepts" regression model, also known as the *parallel slopes* model. However, no argument to plot such models exists within `geom_smooth()`.
 
-[Evgeni Chasnovski](https://github.com/echasnovski){target="_blank"} thus wrote a custom `geom_` extension to `ggplot2` called `geom_parallel_slopes()`; this extension is included in the `moderndive` package. Much like `geom_smooth()` from the `ggplot2` package, you merely add a `geom_parallel_slopes()` layer to the code, resulting in \autoref{fig:parallel-slopes-model}.
+[Evgeni Chasnovski](https://github.com/echasnovski){target="_blank"} thus wrote a custom `geom_` extension to `ggplot2` called `geom_parallel_slopes()`; this extension is included in the `moderndive` package. Much like `geom_smooth()` from the `ggplot2` package, you add `geom_parallel_slopes()` as a layer to the code, resulting in \autoref{fig:parallel-slopes-model}.
 
 ```{r parallel-slopes-model, fig.cap="Visualization of parallel slopes model."}
 # Code to visualize parallel slopes model:
@@ -236,7 +236,7 @@ Instead of `summary()`, let's use the `get_regression_table()` function:
 get_regression_table(score_model)
 ```
 
-Observe how the p-value stars are omitted and confidence intervals for the point estimates of all regression parameters are included by default. By including them in the output, we can easily emphasize to students that they "surround" the point estimates in the `estimate` column. Note the confidence level is defaulted to 95%; this default can be changed using the `conf.level` argument: 
+Observe how the p-value stars are omitted and confidence intervals for the point estimates of all regression parameters are included by default. By including them in the output, we can then emphasize to students that they "surround" the point estimates in the `estimate` column. Note the confidence level is defaulted to 95%; this default can be changed using the `conf.level` argument: 
 
 ```{r}
 get_regression_table(score_model, conf.level = 0.99)
@@ -249,13 +249,13 @@ The second common student question:
 
 > "How do we extract the values in the regression table?"
 
-While one might argue that extracting the intercept and slope coefficients can be simply done using `coefficients(score_model)`, what about the standard errors? For example, a Google query of "_how do I extract standard errors from lm in R_" yielded results from [the R mailing list](https://stat.ethz.ch/pipermail/r-help/2008-April/160538.html){target="_blank"} and from [Cross Validated](https://stats.stackexchange.com/questions/27511/extract-standard-errors-of-coefficient-linear-regression-r){target="_blank"} suggesting we run:
+While one might argue that extracting the intercept and slope coefficients can be "simply" done using `coefficients(score_model)`, what about the standard errors? For example, a Google query of "_how do I extract standard errors from lm in R_" yielded results from [the R mailing list](https://stat.ethz.ch/pipermail/r-help/2008-April/160538.html){target="_blank"} and from [Cross Validated](https://stats.stackexchange.com/questions/27511/extract-standard-errors-of-coefficient-linear-regression-r){target="_blank"} suggesting we run:
 
 ```{r}
 sqrt(diag(vcov(score_model)))
 ```
 
-We argue that this task shouldn't be this hard, especially in an introductory statistics setting. To rectify this, the three `get_regression_*` functions  all return data frames in the tidyverse-style tibble (tidy table) format [@R-tibble]. Therefore you can easily extract columns using the `pull()` function from the `dplyr` package [@R-dplyr]:
+We argue that this task shouldn't be this hard, especially in an introductory statistics setting. To rectify this, the three `get_regression_*` functions  all return data frames in the tidyverse-style tibble (tidy table) format [@R-tibble]. Therefore you can extract columns using the `pull()` function from the `dplyr` package [@R-dplyr]:
 
 
 ```{r}
@@ -310,7 +310,7 @@ score_model_points %>%
   slice(1:10)
 ```
 
-Observe that the original outcome variable `score` and explanatory/predictor variable `age` are now supplemented with the fitted/predicted values `score_hat` and `residual` columns. By putting the fitted values, predicted values, and residuals next to the original data, we argue that the computation of these values is less opaque. For example, instructors can easily emphasize how all values in the first row of output are computed.
+Observe that the original outcome variable `score` and explanatory/predictor variable `age` are now supplemented with the fitted/predicted values `score_hat` and `residual` columns. By putting the fitted values, predicted values, and residuals next to the original data, we argue that the computation of these values is less opaque. For example, instructors can emphasize how all values in the first row of output are computed.
 
 Furthermore, recall that since all outputs in the `moderndive` package are tibble data frames, custom residual analysis plots can be created instead of relying on the default plots yielded by `plot.lm()`. For example, we can check for the normality of residuals using the histogram of residuals shown in \autoref{fig:residuals-1}.
 
@@ -521,7 +521,7 @@ While many students will inevitably find these results depressing, in our opinio
 
 ## Three wrappers to `broom` functions {#broom-wrappers}
 
-As we mentioned earlier, the three `get_regression_*` functions are merely wrappers of functions from the `broom` package for converting statistical analysis objects into tidy tibbles along with a few added tweaks, but with the introductory statistics student in mind [@R-broom]:
+As we mentioned earlier, the three `get_regression_*` functions are wrappers of functions from the `broom` package for converting statistical analysis objects into tidy tibbles along with a few added tweaks, but with the introductory statistics student in mind [@R-broom]:
 
 1. `get_regression_table()` is a wrapper for `broom::tidy()`.
 1. `get_regression_points()` is a wrapper for `broom::augment()`.


### PR DESCRIPTION
Part of JOSE review https://github.com/openjournals/jose-reviews/issues/115

Language like "just", "simply", "easily" have long been pretty common among programming documentation and even stats docs. But to any novice/learner, it often isn't "just" doing something. These words have an implicit "judgement" that the task is easy when for beginners it is anything but easy. You have to know how to do the task in order for it to be "just" or "merely". Also, this language literally provides no other value to the instructions or meaning of the sentence other than to convey that the task is "easy"... which the point of any learning material is that it isn't "just" easy, which is what the material is supposed to teach.

So I removed the few instances of these wordings.