### PR TITLE
Use roxygen md

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,3 +44,4 @@ Suggests:
     viridis,
     readr
 VignetteBuilder: knitr
+Roxygen: list(markdown = TRUE)

--- a/R/datasets.R
+++ b/R/datasets.R
@@ -2,15 +2,15 @@
 #'
 #' A sample of 50 pennies contained in a 50 cent roll from Florence Bank on
 #' Friday February 1, 2019 in downtown Northampton, Massachusetts, USA
-#' \url{https://goo.gl/maps/AF88fpvVfm12}.
+#' <https://goo.gl/maps/AF88fpvVfm12>.
 #'
 #' @format A data frame of 50 rows representing 50 sampled pennies and 2 variables
 #' \describe{
 #'   \item{ID}{Variable used to uniquely identify each penny.}
 #'   \item{year}{Year of minting.}
 #' }
-#' @note The original \code{pennies_sample} has been renamed \code{\link{orig_pennies_sample}}
-#' as of \code{moderndive} v0.3.0.
+#' @note The original `pennies_sample` has been renamed [orig_pennies_sample()]
+#' as of `moderndive` v0.3.0.
 "pennies_sample"
 
 
@@ -19,8 +19,8 @@
 #'
 #' 35 bootstrap resamples with replacement of sample of 50 pennies contained in
 #' a 50 cent roll from Florence Bank on Friday February 1, 2019 in downtown Northampton,
-#' Massachusetts, USA \url{https://goo.gl/maps/AF88fpvVfm12}. The original sample
-#' of 50 pennies is available in \code{\link{pennies_sample}} .
+#' Massachusetts, USA <https://goo.gl/maps/AF88fpvVfm12>. The original sample
+#' of 50 pennies is available in [pennies_sample()] .
 #'
 #' @format A data frame of 1750 rows representing 35 students' bootstrap
 #' resamples of size 50 and 3 variables
@@ -29,7 +29,7 @@
 #'   \item{name}{Name of student}
 #'   \item{year}{Year on resampled penny}
 #' }
-#' @seealso \code{\link{pennies_sample}}
+#' @seealso [pennies_sample()]
 "pennies_resamples"
 
 
@@ -44,23 +44,23 @@
 #'   \item{year}{Year of minting}
 #'   \item{age_in_2011}{Age in 2011}
 #' }
-#' @source StatCrunch \url{https://www.statcrunch.com/app/index.php?dataid=301596}
+#' @source StatCrunch <https://www.statcrunch.com/app/index.php?dataid=301596>
 "pennies"
 
 
 
-#' A random sample of 40 pennies sampled from the \code{pennies} data frame
+#' A random sample of 40 pennies sampled from the `pennies` data frame
 #'
-#' A dataset of 40 pennies to be treated as a random sample with \code{\link{pennies}} acting
+#' A dataset of 40 pennies to be treated as a random sample with [pennies()] acting
 #' as the population. Data on these pennies were recorded in 2011.
 #'
-#' @format A data frame of 40 rows representing 40 randomly sampled pennies from \code{\link{pennies}} and 2 variables
+#' @format A data frame of 40 rows representing 40 randomly sampled pennies from [pennies()] and 2 variables
 #' \describe{
 #'   \item{year}{Year of minting}
 #'   \item{age_in_2011}{Age in 2011}
 #' }
-#' @source StatCrunch \url{https://www.statcrunch.com/app/index.php?dataid=301596}
-#' @seealso \code{\link{pennies}}
+#' @source StatCrunch <https://www.statcrunch.com/app/index.php?dataid=301596>
+#' @seealso [pennies()]
 "orig_pennies_sample"
 
 
@@ -71,7 +71,7 @@
 #' A sampling bowl of red and white balls
 #'
 #' A sampling bowl used as the population in a simulated sampling exercise. Also
-#' known as the urn sampling framework \url{https://en.wikipedia.org/wiki/Urn_problem}.
+#' known as the urn sampling framework <https://en.wikipedia.org/wiki/Urn_problem>.
 #'
 #' @format A data frame 2400 rows representing different balls in the bowl, of which
 #' 900 are red and 1500 are white.
@@ -87,7 +87,7 @@
 #' Sampling from a bowl of balls
 #'
 #' Counting the number of red balls in 10 samples of size n = 50 balls from
-#' \url{https://github.com/moderndive/moderndive/blob/master/data-raw/sampling_bowl.jpeg}
+#' <https://github.com/moderndive/moderndive/blob/master/data-raw/sampling_bowl.jpeg>
 #'
 #' @format A data frame 10 rows representing different groups of students'
 #' samples of size n = 50 and 5 variables
@@ -98,7 +98,7 @@
 #'   \item{green}{Number of green balls sampled}
 #'   \item{n}{Total number of balls samples}
 #' }
-#' @seealso \code{\link{bowl}}
+#' @seealso [bowl()]
 "bowl_samples"
 
 
@@ -106,7 +106,7 @@
 #' Tactile sampling from a tub of balls
 #'
 #' Counting the number of red balls in 33 tactile samples of size n = 50 balls from
-#' \url{https://github.com/moderndive/moderndive/blob/master/data-raw/sampling_bowl.jpeg}
+#' <https://github.com/moderndive/moderndive/blob/master/data-raw/sampling_bowl.jpeg>
 #'
 #' @format A data frame of 33 rows representing different groups of students'
 #' samples of size n = 50 and 4 variables
@@ -116,7 +116,7 @@
 #'   \item{red_balls}{Number of red balls sampled out of 50}
 #'   \item{prop_red}{Proportion red balls out of 50}
 #' }
-#' @seealso \code{\link{bowl}}
+#' @seealso [bowl()]
 "tactile_prop_red"
 
 
@@ -124,13 +124,13 @@
 #' Tactile sample of size 50 from a bowl of balls
 #'
 #' A single tactile sample of size n = 50 balls from
-#' \url{https://github.com/moderndive/moderndive/blob/master/data-raw/sampling_bowl.jpeg}
+#' <https://github.com/moderndive/moderndive/blob/master/data-raw/sampling_bowl.jpeg>
 #'
 #' @format A data frame of 50 rows representing different balls and 1 variable.
 #' \describe{
 #'   \item{color}{Color of ball sampled}
 #' }
-#' @seealso \code{\link{bowl}}
+#' @seealso [bowl()]
 "bowl_sample_1"
 
 
@@ -149,7 +149,7 @@
 #' }
 #' @source Rosen B and Jerdee T. 1974. Influence of sex role stereotypes on personnel
 #' decisions. Journal of Applied Psychology 59(1):9-14.
-#' @seealso The data in `promotions` is a slight modification of \code{\link[openintro]{gender_discrimination}}.
+#' @seealso The data in `promotions` is a slight modification of [openintro::gender_discrimination()].
 "promotions"
 
 
@@ -163,7 +163,7 @@
 #'   \item{gender}{shuffled/permuted (binary) gender: a factor with two levels `male` and `female`}
 #'   \item{decision}{a factor with two levels: `promoted` and `not`}
 #' }
-#' @seealso \code{\link{promotions}}.
+#' @seealso [promotions()].
 "promotions_shuffled"
 
 
@@ -179,8 +179,8 @@
 #'   \item{size}{Size of school enrollment; small 13-341 students, medium 342-541 students, large 542-4264 students.}
 #' }
 #' @source The original source of the data are Massachusetts Department of
-#' Education reports \url{http://profiles.doe.mass.edu/state_report/}, however
-#' the data was downloaded from Kaggle at \url{https://www.kaggle.com/ndalziel/massachusetts-public-schools-data}
+#' Education reports <http://profiles.doe.mass.edu/state_report/>, however
+#' the data was downloaded from Kaggle at <https://www.kaggle.com/ndalziel/massachusetts-public-schools-data>
 "MA_schools"
 
 
@@ -199,7 +199,7 @@
 #'   \item{shop_type}{Coffee shop type: Dunkin Donuts or Starbucks}
 #'   \item{shops}{Number of shops}
 #' }
-#' @source US Census Bureau. Code used to scrape data available at \url{https://github.com/DelaneyMoran/FinalProject}
+#' @source US Census Bureau. Code used to scrape data available at <https://github.com/DelaneyMoran/FinalProject>
 "DD_vs_SB"
 
 
@@ -208,7 +208,7 @@
 #'
 #' This dataset contains house sale prices for King County, which includes
 #' Seattle. It includes homes sold between May 2014 and May 2015. This dataset
-#' was obtained from Kaggle.com \url{https://www.kaggle.com/harlfoxem/housesalesprediction/data}
+#' was obtained from Kaggle.com <https://www.kaggle.com/harlfoxem/housesalesprediction/data>
 #'
 #' @format A data frame with 21613 observations on the following 21 variables.
 #' \describe{
@@ -234,7 +234,7 @@
 #'   \item{sqft_living15}{Living room area in 2015 (implies-- some renovations) This might or might not have affected the lotsize area}
 #'   \item{sqft_lot15}{lotSize area in 2015 (implies-- some renovations)}
 #' }
-#' @source Kaggle \url{https://www.kaggle.com/harlfoxem/housesalesprediction}.
+#' @source Kaggle <https://www.kaggle.com/harlfoxem/housesalesprediction>.
 #' Note data is released under a CC0: Public Domain license.
 "house_prices"
 
@@ -246,7 +246,7 @@
 #' 94 professors from the University of Texas at Austin. In addition, six
 #' students rate the professors' physical appearance. The result is a data frame
 #' where each row contains a different course and each column has information on
-#' either the course or the professor \url{https://www.openintro.org/data/index.php?data=evals}
+#' either the course or the professor <https://www.openintro.org/data/index.php?data=evals>
 #'
 #' @format A data frame with 463 observations corresponding to courses on the following 13 variables.
 #' \describe{
@@ -266,7 +266,7 @@
 #'   \item{cls_level}{Class level: lower, upper.}
 #' }
 #' @source Çetinkaya-Rundel M, Morgan KL, Stangl D. 2013. Looking Good on Course Evaluations. CHANCE 26(2). 
-#' @seealso The data in `evals` is a slight modification of \code{\link[openintro]{evals}}.
+#' @seealso The data in `evals` is a slight modification of [openintro::evals()].
 "evals"
 
 
@@ -274,7 +274,7 @@
 #' Data from Mythbusters' study on contagiousness of yawning
 #'
 #' From a study on whether yawning is contagious
-#' \url{https://www.imdb.com/title/tt0768479/}.
+#' <https://www.imdb.com/title/tt0768479/>.
 #' The data here was derived from the final proportions of yawns given
 #' in the show.
 #'
@@ -283,10 +283,10 @@
 #' \describe{
 #'   \item{subj}{integer value corresponding to identifier variable of
 #'   subject ID}
-#'   \item{group}{string of either \code{"seed"}, participant was shown a
-#'   yawner, or \code{"control"}, participant was not shown a yawner}
-#'   \item{yawn}{string of either \code{"yes"}, the participant yawned, or
-#'   \code{"no"}, the participant did not yawn}
+#'   \item{group}{string of either `"seed"`, participant was shown a
+#'   yawner, or `"control"`, participant was not shown a yawner}
+#'   \item{yawn}{string of either `"yes"`, the participant yawned, or
+#'   `"no"`, the participant did not yawn}
 #' }
 "mythbusters_yawn"
 
@@ -295,7 +295,7 @@
 #' Random sample of 68 action and romance movies
 #'
 #' A random sample of 32 action movies and 36 romance movies from
-#' \url{https://www.imdb.com/} and their ratings.
+#' <https://www.imdb.com/> and their ratings.
 #'
 #' @format A data frame of 68 rows movies.
 #' \describe{
@@ -304,5 +304,5 @@
 #'   \item{rating}{IMDb rating out of 10 stars}
 #'   \item{genre}{Action or Romance}
 #' }
-#' @seealso This data was sampled from the `movies` data frame in the \code{ggplot2movies} package.
+#' @seealso This data was sampled from the `movies` data frame in the `ggplot2movies` package.
 "movies_sample"

--- a/R/geom_categorical_model.R
+++ b/R/geom_categorical_model.R
@@ -1,14 +1,14 @@
 #' Regression model with one categorical explanatory/predictor variable
 #'
-#' \code{geom_categorical_model()} fits a regression model using the categorical
+#' `geom_categorical_model()` fits a regression model using the categorical
 #' x axis as the explanatory variable, and visualizes the model's fitted values
 #' as piecewise horizontal line segments. Confidence interval bands can be
-#' included in the visualization of the model. Like \code{\link{geom_parallel_slopes}},
-#' this function has the same nature as \code{geom_smooth()} from
-#' the {ggplot2} package, but provides functionality that \code{geom_smooth()}
+#' included in the visualization of the model. Like [geom_parallel_slopes()],
+#' this function has the same nature as `geom_smooth()` from
+#' the {ggplot2} package, but provides functionality that `geom_smooth()`
 #' currently doesn't have.
 #'
-#' @param se Display confidence interval around model lines? \code{TRUE} by
+#' @param se Display confidence interval around model lines? `TRUE` by
 #'   default.
 #'
 #' @param level Level of confidence interval to use (0.95 by default).
@@ -16,7 +16,7 @@
 #' @inheritParams ggplot2::layer
 #' @inheritParams ggplot2::geom_smooth
 #'
-#' @seealso \code{\link{geom_parallel_slopes}}
+#' @seealso [geom_parallel_slopes()]
 #' @export
 #'
 #' @examples

--- a/R/geom_parallel_slopes.R
+++ b/R/geom_parallel_slopes.R
@@ -1,23 +1,23 @@
 #' Parallel slopes regression model
 #'
-#' \code{geom_parallel_slopes()} fits parallel slopes model and adds its line
-#' output(s) to a \code{ggplot} object. Basically, it fits a unified model with
+#' `geom_parallel_slopes()` fits parallel slopes model and adds its line
+#' output(s) to a `ggplot` object. Basically, it fits a unified model with
 #' intercepts varying between groups (which should be supplied as standard
-#' {ggplot2} grouping aesthetics: \code{group}, \code{color}, \code{fill},
-#' etc.). This function has the same nature as \code{geom_smooth()} from
-#' {ggplot2} package, but provides functionality that \code{geom_smooth()}
+#' {ggplot2} grouping aesthetics: `group`, `color`, `fill`,
+#' etc.). This function has the same nature as `geom_smooth()` from
+#' {ggplot2} package, but provides functionality that `geom_smooth()`
 #' currently doesn't have.
 #'
-#' @param se Display confidence interval around model lines? \code{TRUE} by
+#' @param se Display confidence interval around model lines? `TRUE` by
 #'   default.
 #' @param formula Formula to use per group in parallel slopes model. Basic
-#'   linear \code{y ~ x} by default.
+#'   linear `y ~ x` by default.
 #' @param n Number of points per group at which to evaluate model.
 #' @inheritParams ggplot2::layer
 #' @inheritParams ggplot2::geom_smooth
 #' @inheritParams ggplot2::stat_smooth
 #'
-#' @seealso \code{\link{geom_categorical_model}}
+#' @seealso [geom_categorical_model()]
 #' @export
 #'
 #' @examples

--- a/R/get_correlation.R
+++ b/R/get_correlation.R
@@ -8,7 +8,7 @@
 #' the explanatory variable name on the right
 #' @param na.rm a logical value indicating whether NA values should be stripped
 #' before the computation proceeds.
-#' @param ... further arguments passed to \code{\link[stats]{cor}}
+#' @param ... further arguments passed to [stats::cor()]
 #'
 #' @return A 1x1 data frame storing the correlation value
 #' @importFrom magrittr "%>%"

--- a/R/ggplot_parallel_slopes.R
+++ b/R/ggplot_parallel_slopes.R
@@ -4,20 +4,20 @@ globalVariables(c(
 
 #' Plot parallel slopes model
 #'
-#' NOTE: This function is deprecated; please use \code{\link{geom_parallel_slopes}}
+#' NOTE: This function is deprecated; please use [geom_parallel_slopes()]
 #' instead. Output a visualization of linear regression when you have one numerical
 #' and one categorical explanatory/predictor variable: a separate colored
 #' regression line for each level of the categorical variable
 #'
 #' @inheritParams stats::lm
-#' @param y Character string of outcome variable in \code{data}
+#' @param y Character string of outcome variable in `data`
 #' @param num_x Character string of numerical explanatory/predictor variable in
-#'   \code{data}
+#'   `data`
 #' @param cat_x Character string of categorical explanatory/predictor variable
-#'   in \code{data}
+#'   in `data`
 #' @param alpha Transparency of points
-#' @seealso \code{\link{geom_parallel_slopes}}
-#' @return A \code{\link[ggplot2]{ggplot}} object.
+#' @seealso [geom_parallel_slopes()]
+#' @return A [ggplot2::ggplot()] object.
 #' @importFrom glue glue
 #' @importFrom stats as.formula
 #' @import ggplot2

--- a/R/moderndive.R
+++ b/R/moderndive.R
@@ -2,7 +2,7 @@
 #'
 #' Datasets and wrapper functions for tidyverse-friendly introductory linear
 #' regression, used in "Statistical Inference via Data Science: A ModernDive
-#' into R and the tidyverse" available at \url{https://moderndive.com/}.
+#' into R and the tidyverse" available at <https://moderndive.com/>.
 #'
 #' @docType package
 #' @name moderndive

--- a/R/regression_functions.R
+++ b/R/regression_functions.R
@@ -6,11 +6,11 @@ globalVariables(c(
 
 #' Get regression table
 #'
-#' Output regression table for an \code{lm()} regression in "tidy" format. This function
-#' is a wrapper function for \code{broom::tidy()} and includes confidence
+#' Output regression table for an `lm()` regression in "tidy" format. This function
+#' is a wrapper function for `broom::tidy()` and includes confidence
 #' intervals in the output table by default.
 #'
-#' @param model an \code{lm()} model object
+#' @param model an `lm()` model object
 #' @inheritParams broom::tidy.lm
 #' @param digits number of digits precision in output table
 #' @param print If TRUE, return in print format suitable for R Markdown
@@ -20,8 +20,8 @@ globalVariables(c(
 #'  "categorical_variable_name: level_name"
 #'
 #' @return A tibble-formatted regression table along with lower and upper end
-#' points of all confidence intervals for all parameters \code{lower_ci} and
-#' \code{upper_ci}; the confidence levels default to 95\%. 
+#' points of all confidence intervals for all parameters `lower_ci` and
+#' `upper_ci`; the confidence levels default to 95\%. 
 #' @importFrom stats lm
 #' @importFrom stats predict
 #' @importFrom formula.tools lhs
@@ -31,7 +31,7 @@ globalVariables(c(
 #' @importFrom janitor clean_names
 #' @importFrom knitr kable
 #' @export
-#' @seealso \code{\link[broom:reexports]{tidy}}, \code{\link{get_regression_points}}, \code{\link{get_regression_summaries}}
+#' @seealso [`tidy()`][broom::reexports], [get_regression_points()], [get_regression_summaries()]
 #'
 #' @examples
 #' library(moderndive)
@@ -82,20 +82,20 @@ get_regression_table <- function(model, conf.level = 0.95, digits = 3, print = F
 
 #' Get regression points
 #'
-#' Output information on each point/observation used in an \code{lm()} regression in
-#' "tidy" format. This function is a wrapper function for \code{broom::augment()}
+#' Output information on each point/observation used in an `lm()` regression in
+#' "tidy" format. This function is a wrapper function for `broom::augment()`
 #' and renames the variables to have more intuitive names.
 #'
 #' @inheritParams get_regression_table
-#' @param newdata A new data frame of points/observations to apply \code{model} to
+#' @param newdata A new data frame of points/observations to apply `model` to
 #' obtain new fitted values and/or predicted values y-hat. Note the format of
-#' \code{newdata} must match the format of the original \code{data} used to fit
-#' \code{model}.
+#' `newdata` must match the format of the original `data` used to fit
+#' `model`.
 #' @param ID A string indicating which variable in either the original data used to fit
-#' \code{model} or \code{newdata} should be used as
+#' `model` or `newdata` should be used as
 #' an identification variable to distinguish the observational units
 #' in each row. This variable will be the left-most variable in the output data
-#' frame. If \code{ID} is unspecified, a column \code{ID} with values 1 through the number of
+#' frame. If `ID` is unspecified, a column `ID` with values 1 through the number of
 #' rows is returned as the identification variable.
 #'
 #' @return A tibble-formatted regression table of outcome/response variable,
@@ -120,7 +120,7 @@ get_regression_table <- function(model, conf.level = 0.95, digits = 3, print = F
 #' @importFrom rlang sym
 #' @importFrom rlang ":="
 #' @export
-#' @seealso \code{\link[broom:reexports]{augment}}, \code{\link{get_regression_table}}, \code{\link{get_regression_summaries}}
+#' @seealso [`augment()`][broom::reexports], [get_regression_table()], [get_regression_summaries()]
 #'
 #' @examples
 #' library(dplyr)
@@ -247,12 +247,12 @@ get_regression_points <-
 
 #' Get regression summary values
 #'
-#' Output scalar summary statistics for an \code{lm()} regression in "tidy"
-#' format. This function is a wrapper function for \code{broom::glance()}.
+#' Output scalar summary statistics for an `lm()` regression in "tidy"
+#' format. This function is a wrapper function for `broom::glance()`.
 #'
 #' @inheritParams get_regression_table
 #'
-#' @return A single-row tibble with regression summaries. Ex: \code{r_squared} and \code{mse}.
+#' @return A single-row tibble with regression summaries. Ex: `r_squared` and `mse`.
 #' @importFrom dplyr select
 #' @importFrom dplyr rename_at
 #' @importFrom dplyr vars
@@ -272,7 +272,7 @@ get_regression_points <-
 #' @importFrom janitor clean_names
 #' @importFrom knitr kable
 #' @export
-#' @seealso \code{\link[broom:reexports]{glance}}, \code{\link{get_regression_table}}, \code{\link{get_regression_points}}
+#' @seealso [`glance()`][broom::reexports], [get_regression_table()], [get_regression_points()]
 #'
 #' @examples
 #' library(moderndive)

--- a/R/utils-pipe.R
+++ b/R/utils-pipe.R
@@ -1,6 +1,6 @@
 #' Pipe operator
 #'
-#' See \code{magrittr::\link[magrittr:pipe]{\%>\%}} for details.
+#' See `magrittr::[\%>\%][magrittr::pipe]` for details.
 #'
 #' @name %>%
 #' @rdname pipe

--- a/man/DD_vs_SB.Rd
+++ b/man/DD_vs_SB.Rd
@@ -7,12 +7,12 @@
 \format{
 A data frame of 1024 rows representing census tracts and 6 variables
 \describe{
-  \item{county}{County where census tract is located. Either Bristol, Essex, Middlesex, Norfolk, Plymouth, or Suffolk county}
-  \item{FIPS}{Federal Information Processing Standards code identifying census tract}
-  \item{median_income}{Median income of census tract}
-  \item{population}{Population of census tract}
-  \item{shop_type}{Coffee shop type: Dunkin Donuts or Starbucks}
-  \item{shops}{Number of shops}
+\item{county}{County where census tract is located. Either Bristol, Essex, Middlesex, Norfolk, Plymouth, or Suffolk county}
+\item{FIPS}{Federal Information Processing Standards code identifying census tract}
+\item{median_income}{Median income of census tract}
+\item{population}{Population of census tract}
+\item{shop_type}{Coffee shop type: Dunkin Donuts or Starbucks}
+\item{shops}{Number of shops}
 }
 }
 \source{

--- a/man/MA_schools.Rd
+++ b/man/MA_schools.Rd
@@ -7,10 +7,10 @@
 \format{
 A data frame of 332 rows representing Massachusetts high schools and 4 variables
 \describe{
-  \item{school_name}{High school name.}
-  \item{average_sat_math}{Average SAT math score. Note 58 of the original 390 values of this variable were missing; these rows were dropped from consideration.}
-  \item{perc_disadvan}{Percent of the student body that are considered economically disadvantaged.}
-  \item{size}{Size of school enrollment; small 13-341 students, medium 342-541 students, large 542-4264 students.}
+\item{school_name}{High school name.}
+\item{average_sat_math}{Average SAT math score. Note 58 of the original 390 values of this variable were missing; these rows were dropped from consideration.}
+\item{perc_disadvan}{Percent of the student body that are considered economically disadvantaged.}
+\item{size}{Size of school enrollment; small 13-341 students, medium 342-541 students, large 542-4264 students.}
 }
 }
 \source{

--- a/man/bowl.Rd
+++ b/man/bowl.Rd
@@ -8,9 +8,9 @@
 A data frame 2400 rows representing different balls in the bowl, of which
 900 are red and 1500 are white.
 \describe{
-  \item{ball_ID}{ID variable used to denote all balls. Note this value is not
-  marked on the balls themselves}
-  \item{color}{color of ball: red or white}
+\item{ball_ID}{ID variable used to denote all balls. Note this value is not
+marked on the balls themselves}
+\item{color}{color of ball: red or white}
 }
 }
 \usage{

--- a/man/bowl_sample_1.Rd
+++ b/man/bowl_sample_1.Rd
@@ -7,7 +7,7 @@
 \format{
 A data frame of 50 rows representing different balls and 1 variable.
 \describe{
-  \item{color}{Color of ball sampled}
+\item{color}{Color of ball sampled}
 }
 }
 \usage{
@@ -18,6 +18,6 @@ A single tactile sample of size n = 50 balls from
 \url{https://github.com/moderndive/moderndive/blob/master/data-raw/sampling_bowl.jpeg}
 }
 \seealso{
-\code{\link{bowl}}
+\code{\link[=bowl]{bowl()}}
 }
 \keyword{datasets}

--- a/man/bowl_samples.Rd
+++ b/man/bowl_samples.Rd
@@ -8,11 +8,11 @@
 A data frame 10 rows representing different groups of students'
 samples of size n = 50 and 5 variables
 \describe{
-  \item{group}{Group name}
-  \item{red}{Number of red balls sampled}
-  \item{white}{Number of white balls sampled}
-  \item{green}{Number of green balls sampled}
-  \item{n}{Total number of balls samples}
+\item{group}{Group name}
+\item{red}{Number of red balls sampled}
+\item{white}{Number of white balls sampled}
+\item{green}{Number of green balls sampled}
+\item{n}{Total number of balls samples}
 }
 }
 \usage{
@@ -23,6 +23,6 @@ Counting the number of red balls in 10 samples of size n = 50 balls from
 \url{https://github.com/moderndive/moderndive/blob/master/data-raw/sampling_bowl.jpeg}
 }
 \seealso{
-\code{\link{bowl}}
+\code{\link[=bowl]{bowl()}}
 }
 \keyword{datasets}

--- a/man/evals.Rd
+++ b/man/evals.Rd
@@ -7,20 +7,20 @@
 \format{
 A data frame with 463 observations corresponding to courses on the following 13 variables.
 \describe{
-  \item{ID}{Identification variable for course.}
-  \item{prof_ID}{Identification variable for professor. Many professors are included more than once in this dataset.}
-  \item{score}{Average professor evaluation score: (1) very unsatisfactory - (5) excellent.}
-  \item{age}{Age of professor.}
-  \item{bty_avg}{Average beauty rating of professor.}
-  \item{gender}{Gender of professor (collected as a binary variable at the time of the study): female, male.}
-  \item{ethnicity}{Ethnicity of professor: not minority, minority.}
-  \item{language}{Language of school where professor received education: English or non-English.}
-  \item{rank}{Rank of professor: teaching, tenure track, tenured.}
-  \item{pic_outfit}{Outfit of professor in picture: not formal, formal.}
-  \item{pic_color}{Color of professor’s picture: color, black & white.}
-  \item{cls_did_eval}{Number of students in class who completed evaluation.}
-  \item{cls_students}{Total number of students in class.}
-  \item{cls_level}{Class level: lower, upper.}
+\item{ID}{Identification variable for course.}
+\item{prof_ID}{Identification variable for professor. Many professors are included more than once in this dataset.}
+\item{score}{Average professor evaluation score: (1) very unsatisfactory - (5) excellent.}
+\item{age}{Age of professor.}
+\item{bty_avg}{Average beauty rating of professor.}
+\item{gender}{Gender of professor (collected as a binary variable at the time of the study): female, male.}
+\item{ethnicity}{Ethnicity of professor: not minority, minority.}
+\item{language}{Language of school where professor received education: English or non-English.}
+\item{rank}{Rank of professor: teaching, tenure track, tenured.}
+\item{pic_outfit}{Outfit of professor in picture: not formal, formal.}
+\item{pic_color}{Color of professor’s picture: color, black & white.}
+\item{cls_did_eval}{Number of students in class who completed evaluation.}
+\item{cls_students}{Total number of students in class.}
+\item{cls_level}{Class level: lower, upper.}
 }
 }
 \source{
@@ -37,6 +37,6 @@ where each row contains a different course and each column has information on
 either the course or the professor \url{https://www.openintro.org/data/index.php?data=evals}
 }
 \seealso{
-The data in `evals` is a slight modification of \code{\link[openintro]{evals}}.
+The data in \code{evals} is a slight modification of \code{\link[openintro:evals]{openintro::evals()}}.
 }
 \keyword{datasets}

--- a/man/geom_categorical_model.Rd
+++ b/man/geom_categorical_model.Rd
@@ -68,7 +68,7 @@ the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 \code{geom_categorical_model()} fits a regression model using the categorical
 x axis as the explanatory variable, and visualizes the model's fitted values
 as piecewise horizontal line segments. Confidence interval bands can be
-included in the visualization of the model. Like \code{\link{geom_parallel_slopes}},
+included in the visualization of the model. Like \code{\link[=geom_parallel_slopes]{geom_parallel_slopes()}},
 this function has the same nature as \code{geom_smooth()} from
 the {ggplot2} package, but provides functionality that \code{geom_smooth()}
 currently doesn't have.
@@ -89,5 +89,5 @@ p \%+\% aes(color = drv)
 p \%+\% aes(color = class)
 }
 \seealso{
-\code{\link{geom_parallel_slopes}}
+\code{\link[=geom_parallel_slopes]{geom_parallel_slopes()}}
 }

--- a/man/geom_parallel_slopes.Rd
+++ b/man/geom_parallel_slopes.Rd
@@ -122,5 +122,5 @@ ggplot(example_df, aes(x = log10_size, y = log10_price)) +
   geom_parallel_slopes(aes(fill = condition))
 }
 \seealso{
-\code{\link{geom_categorical_model}}
+\code{\link[=geom_categorical_model]{geom_categorical_model()}}
 }

--- a/man/get_correlation.Rd
+++ b/man/get_correlation.Rd
@@ -15,7 +15,7 @@ the explanatory variable name on the right}
 \item{na.rm}{a logical value indicating whether NA values should be stripped
 before the computation proceeds.}
 
-\item{...}{further arguments passed to \code{\link[stats]{cor}}}
+\item{...}{further arguments passed to \code{\link[stats:cor]{stats::cor()}}}
 }
 \value{
 A 1x1 data frame storing the correlation value

--- a/man/get_regression_points.Rd
+++ b/man/get_regression_points.Rd
@@ -67,5 +67,5 @@ mpg_model_train <- lm(mpg ~ cyl, data = training_set)
 get_regression_points(mpg_model_train, newdata = test_set, ID = "automobile")
 }
 \seealso{
-\code{\link[broom:reexports]{augment}}, \code{\link{get_regression_table}}, \code{\link{get_regression_summaries}}
+\code{\link[broom:reexports]{augment()}}, \code{\link[=get_regression_table]{get_regression_table()}}, \code{\link[=get_regression_summaries]{get_regression_summaries()}}
 }

--- a/man/get_regression_summaries.Rd
+++ b/man/get_regression_summaries.Rd
@@ -30,5 +30,5 @@ mpg_model <- lm(mpg ~ cyl, data = mtcars)
 get_regression_summaries(mpg_model)
 }
 \seealso{
-\code{\link[broom:reexports]{glance}}, \code{\link{get_regression_table}}, \code{\link{get_regression_points}}
+\code{\link[broom:reexports]{glance()}}, \code{\link[=get_regression_table]{get_regression_table()}}, \code{\link[=get_regression_points]{get_regression_points()}}
 }

--- a/man/get_regression_table.Rd
+++ b/man/get_regression_table.Rd
@@ -24,14 +24,14 @@ Defaults to 0.95, which corresponds to a 95 percent confidence interval.}
 \item{print}{If TRUE, return in print format suitable for R Markdown}
 
 \item{default_categorical_levels}{If TRUE, do not change the non-baseline
-categorical variables in the term column. Otherwise non-baseline 
-categorical variables will be displayed in the format 
+categorical variables in the term column. Otherwise non-baseline
+categorical variables will be displayed in the format
 "categorical_variable_name: level_name"}
 }
 \value{
 A tibble-formatted regression table along with lower and upper end
 points of all confidence intervals for all parameters \code{lower_ci} and
-\code{upper_ci}; the confidence levels default to 95\%.
+\code{upper_ci}; the confidence levels default to 95\\%.
 }
 \description{
 Output regression table for an \code{lm()} regression in "tidy" format. This function
@@ -51,5 +51,5 @@ get_regression_table(mpg_model)
 get_regression_table(mpg_model, conf.level = 0.99)
 }
 \seealso{
-\code{\link[broom:reexports]{tidy}}, \code{\link{get_regression_points}}, \code{\link{get_regression_summaries}}
+\code{\link[broom:reexports]{tidy()}}, \code{\link[=get_regression_points]{get_regression_points()}}, \code{\link[=get_regression_summaries]{get_regression_summaries()}}
 }

--- a/man/gg_parallel_slopes.Rd
+++ b/man/gg_parallel_slopes.Rd
@@ -24,10 +24,10 @@ in \code{data}}
 \item{alpha}{Transparency of points}
 }
 \value{
-A \code{\link[ggplot2]{ggplot}} object.
+A \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}} object.
 }
 \description{
-NOTE: This function is deprecated; please use \code{\link{geom_parallel_slopes}}
+NOTE: This function is deprecated; please use \code{\link[=geom_parallel_slopes]{geom_parallel_slopes()}}
 instead. Output a visualization of linear regression when you have one numerical
 and one categorical explanatory/predictor variable: a separate colored
 regression line for each level of the categorical variable
@@ -66,5 +66,5 @@ ggplot(house_prices, aes(x = log10_size, y = log10_price, col = condition)) +
 }
 }
 \seealso{
-\code{\link{geom_parallel_slopes}}
+\code{\link[=geom_parallel_slopes]{geom_parallel_slopes()}}
 }

--- a/man/house_prices.Rd
+++ b/man/house_prices.Rd
@@ -7,27 +7,27 @@
 \format{
 A data frame with 21613 observations on the following 21 variables.
 \describe{
-  \item{id}{a notation for a house}
-  \item{date}{Date house was sold}
-  \item{price}{Price is prediction target}
-  \item{bedrooms}{Number of Bedrooms/House}
-  \item{bathrooms}{Number of bathrooms/bedrooms}
-  \item{sqft_living}{square footage of the home}
-  \item{sqft_lot}{square footage of the lot}
-  \item{floors}{Total floors (levels) in house}
-  \item{waterfront}{House which has a view to a waterfront}
-  \item{view}{Has been viewed}
-  \item{condition}{How good the condition is (Overall)}
-  \item{grade}{overall grade given to the housing unit, based on King County grading system}
-  \item{sqft_above}{square footage of house apart from basement}
-  \item{sqft_basement}{square footage of the basement}
-  \item{yr_built}{Built Year}
-  \item{yr_renovated}{Year when house was renovated}
-  \item{zipcode}{zip code}
-  \item{lat}{Latitude coordinate}
-  \item{long}{Longitude coordinate}
-  \item{sqft_living15}{Living room area in 2015 (implies-- some renovations) This might or might not have affected the lotsize area}
-  \item{sqft_lot15}{lotSize area in 2015 (implies-- some renovations)}
+\item{id}{a notation for a house}
+\item{date}{Date house was sold}
+\item{price}{Price is prediction target}
+\item{bedrooms}{Number of Bedrooms/House}
+\item{bathrooms}{Number of bathrooms/bedrooms}
+\item{sqft_living}{square footage of the home}
+\item{sqft_lot}{square footage of the lot}
+\item{floors}{Total floors (levels) in house}
+\item{waterfront}{House which has a view to a waterfront}
+\item{view}{Has been viewed}
+\item{condition}{How good the condition is (Overall)}
+\item{grade}{overall grade given to the housing unit, based on King County grading system}
+\item{sqft_above}{square footage of house apart from basement}
+\item{sqft_basement}{square footage of the basement}
+\item{yr_built}{Built Year}
+\item{yr_renovated}{Year when house was renovated}
+\item{zipcode}{zip code}
+\item{lat}{Latitude coordinate}
+\item{long}{Longitude coordinate}
+\item{sqft_living15}{Living room area in 2015 (implies-- some renovations) This might or might not have affected the lotsize area}
+\item{sqft_lot15}{lotSize area in 2015 (implies-- some renovations)}
 }
 }
 \source{

--- a/man/movies_sample.Rd
+++ b/man/movies_sample.Rd
@@ -7,10 +7,10 @@
 \format{
 A data frame of 68 rows movies.
 \describe{
-  \item{title}{Movie title}
-  \item{year}{Year released}
-  \item{rating}{IMDb rating out of 10 stars}
-  \item{genre}{Action or Romance}
+\item{title}{Movie title}
+\item{year}{Year released}
+\item{rating}{IMDb rating out of 10 stars}
+\item{genre}{Action or Romance}
 }
 }
 \usage{
@@ -21,6 +21,6 @@ A random sample of 32 action movies and 36 romance movies from
 \url{https://www.imdb.com/} and their ratings.
 }
 \seealso{
-This data was sampled from the `movies` data frame in the \code{ggplot2movies} package.
+This data was sampled from the \code{movies} data frame in the \code{ggplot2movies} package.
 }
 \keyword{datasets}

--- a/man/mythbusters_yawn.Rd
+++ b/man/mythbusters_yawn.Rd
@@ -8,12 +8,12 @@
 A data frame of 50 rows representing each of the 50 participants
 in the study.
 \describe{
-  \item{subj}{integer value corresponding to identifier variable of
-  subject ID}
-  \item{group}{string of either \code{"seed"}, participant was shown a
-  yawner, or \code{"control"}, participant was not shown a yawner}
-  \item{yawn}{string of either \code{"yes"}, the participant yawned, or
-  \code{"no"}, the participant did not yawn}
+\item{subj}{integer value corresponding to identifier variable of
+subject ID}
+\item{group}{string of either \code{"seed"}, participant was shown a
+yawner, or \code{"control"}, participant was not shown a yawner}
+\item{yawn}{string of either \code{"yes"}, the participant yawned, or
+\code{"no"}, the participant did not yawn}
 }
 }
 \usage{

--- a/man/orig_pennies_sample.Rd
+++ b/man/orig_pennies_sample.Rd
@@ -5,10 +5,10 @@
 \alias{orig_pennies_sample}
 \title{A random sample of 40 pennies sampled from the \code{pennies} data frame}
 \format{
-A data frame of 40 rows representing 40 randomly sampled pennies from \code{\link{pennies}} and 2 variables
+A data frame of 40 rows representing 40 randomly sampled pennies from \code{\link[=pennies]{pennies()}} and 2 variables
 \describe{
-  \item{year}{Year of minting}
-  \item{age_in_2011}{Age in 2011}
+\item{year}{Year of minting}
+\item{age_in_2011}{Age in 2011}
 }
 }
 \source{
@@ -18,10 +18,10 @@ StatCrunch \url{https://www.statcrunch.com/app/index.php?dataid=301596}
 orig_pennies_sample
 }
 \description{
-A dataset of 40 pennies to be treated as a random sample with \code{\link{pennies}} acting
+A dataset of 40 pennies to be treated as a random sample with \code{\link[=pennies]{pennies()}} acting
 as the population. Data on these pennies were recorded in 2011.
 }
 \seealso{
-\code{\link{pennies}}
+\code{\link[=pennies]{pennies()}}
 }
 \keyword{datasets}

--- a/man/pennies.Rd
+++ b/man/pennies.Rd
@@ -7,8 +7,8 @@
 \format{
 A data frame of 800 rows representing different pennies and 2 variables
 \describe{
-  \item{year}{Year of minting}
-  \item{age_in_2011}{Age in 2011}
+\item{year}{Year of minting}
+\item{age_in_2011}{Age in 2011}
 }
 }
 \source{

--- a/man/pennies_resamples.Rd
+++ b/man/pennies_resamples.Rd
@@ -8,9 +8,9 @@
 A data frame of 1750 rows representing 35 students' bootstrap
 resamples of size 50 and 3 variables
 \describe{
-  \item{replicate}{ID variable of replicate/resample number.}
-  \item{name}{Name of student}
-  \item{year}{Year on resampled penny}
+\item{replicate}{ID variable of replicate/resample number.}
+\item{name}{Name of student}
+\item{year}{Year on resampled penny}
 }
 }
 \usage{
@@ -20,9 +20,9 @@ pennies_resamples
 35 bootstrap resamples with replacement of sample of 50 pennies contained in
 a 50 cent roll from Florence Bank on Friday February 1, 2019 in downtown Northampton,
 Massachusetts, USA \url{https://goo.gl/maps/AF88fpvVfm12}. The original sample
-of 50 pennies is available in \code{\link{pennies_sample}} .
+of 50 pennies is available in \code{\link[=pennies_sample]{pennies_sample()}} .
 }
 \seealso{
-\code{\link{pennies_sample}}
+\code{\link[=pennies_sample]{pennies_sample()}}
 }
 \keyword{datasets}

--- a/man/pennies_sample.Rd
+++ b/man/pennies_sample.Rd
@@ -7,8 +7,8 @@
 \format{
 A data frame of 50 rows representing 50 sampled pennies and 2 variables
 \describe{
-  \item{ID}{Variable used to uniquely identify each penny.}
-  \item{year}{Year of minting.}
+\item{ID}{Variable used to uniquely identify each penny.}
+\item{year}{Year of minting.}
 }
 }
 \usage{
@@ -20,7 +20,7 @@ Friday February 1, 2019 in downtown Northampton, Massachusetts, USA
 \url{https://goo.gl/maps/AF88fpvVfm12}.
 }
 \note{
-The original \code{pennies_sample} has been renamed \code{\link{orig_pennies_sample}}
+The original \code{pennies_sample} has been renamed \code{\link[=orig_pennies_sample]{orig_pennies_sample()}}
 as of \code{moderndive} v0.3.0.
 }
 \keyword{datasets}

--- a/man/pipe.Rd
+++ b/man/pipe.Rd
@@ -7,6 +7,6 @@
 lhs \%>\% rhs
 }
 \description{
-See \code{magrittr::\link[magrittr:pipe]{\%>\%}} for details.
+See \verb{magrittr::[\\\%>\\\%][magrittr::pipe]} for details.
 }
 \keyword{internal}

--- a/man/promotions.Rd
+++ b/man/promotions.Rd
@@ -7,9 +7,9 @@
 \format{
 A data frame with 48 observations on the following 3 variables.
 \describe{
-  \item{id}{Identification variable used to distinguish rows.}
-  \item{gender}{gender (collected as a binary variable at the time of the study): a factor with two levels `male` and `female`}
-  \item{decision}{a factor with two levels: `promoted` and `not`}
+\item{id}{Identification variable used to distinguish rows.}
+\item{gender}{gender (collected as a binary variable at the time of the study): a factor with two levels \code{male} and \code{female}}
+\item{decision}{a factor with two levels: \code{promoted} and \code{not}}
 }
 }
 \source{
@@ -24,6 +24,6 @@ Data from a 1970's study on whether gender influences hiring recommendations.
 Originally used in OpenIntro.org.
 }
 \seealso{
-The data in `promotions` is a slight modification of \code{\link[openintro]{gender_discrimination}}.
+The data in \code{promotions} is a slight modification of \code{\link[openintro:gender_discrimination]{openintro::gender_discrimination()}}.
 }
 \keyword{datasets}

--- a/man/promotions_shuffled.Rd
+++ b/man/promotions_shuffled.Rd
@@ -7,9 +7,9 @@
 \format{
 A data frame with 48 observations on the following 3 variables.
 \describe{
-  \item{id}{Identification variable used to distinguish rows.}
-  \item{gender}{shuffled/permuted (binary) gender: a factor with two levels `male` and `female`}
-  \item{decision}{a factor with two levels: `promoted` and `not`}
+\item{id}{Identification variable used to distinguish rows.}
+\item{gender}{shuffled/permuted (binary) gender: a factor with two levels \code{male} and \code{female}}
+\item{decision}{a factor with two levels: \code{promoted} and \code{not}}
 }
 }
 \usage{
@@ -19,6 +19,6 @@ promotions_shuffled
 Shuffled/permuted data from a 1970's study on whether gender influences hiring recommendations.
 }
 \seealso{
-\code{\link{promotions}}.
+\code{\link[=promotions]{promotions()}}.
 }
 \keyword{datasets}

--- a/man/tactile_prop_red.Rd
+++ b/man/tactile_prop_red.Rd
@@ -8,10 +8,10 @@
 A data frame of 33 rows representing different groups of students'
 samples of size n = 50 and 4 variables
 \describe{
-  \item{group}{Group members}
-  \item{replicate}{Replicate number}
-  \item{red_balls}{Number of red balls sampled out of 50}
-  \item{prop_red}{Proportion red balls out of 50}
+\item{group}{Group members}
+\item{replicate}{Replicate number}
+\item{red_balls}{Number of red balls sampled out of 50}
+\item{prop_red}{Proportion red balls out of 50}
 }
 }
 \usage{
@@ -22,6 +22,6 @@ Counting the number of red balls in 33 tactile samples of size n = 50 balls from
 \url{https://github.com/moderndive/moderndive/blob/master/data-raw/sampling_bowl.jpeg}
 }
 \seealso{
-\code{\link{bowl}}
+\code{\link[=bowl]{bowl()}}
 }
 \keyword{datasets}


### PR DESCRIPTION
instead of old Rd format for documentation. Running `usethis::use_roxygen_md()` not only enables roxygen over Rd, but also converts existing Rd code!