### PR TITLE
Add rep_slice_sample

### DIFF
--- a/R/rep_sample_n.R
+++ b/R/rep_sample_n.R
@@ -1,3 +1,7 @@
 ##' @importFrom infer rep_sample_n
 ##' @export
 infer::rep_sample_n
+
+##' @importFrom infer rep_slice_sample
+##' @export
+infer::rep_slice_sample


### PR DESCRIPTION
Needed for changing over `rep_sample_n()` to `rep_slice_sample()` in ModernDive v2