### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Authors@R: c(
 Maintainer: Albert Y. Kim <albert.ys.kim@gmail.com>
 Description: Datasets and wrapper functions for tidyverse-friendly introductory linear regression, used in "Statistical Inference via Data Science: A ModernDive into R and the Tidyverse" available at <https://moderndive.com/>.
 Depends:
-    R (>= 3.4.0)
+    R (>= 4.1.0)
 License: GPL-3
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
To allow for `|>` to be used. Could switch back to `%>%` if wanting to be more inclusive, but R 4.1.0 has been out for over a year now too.