### PR TITLE
View(): render a static HTML table in webR (fixes the book's in-browser View())

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: moderndive
 Type: Package
 Title: Tidyverse-Friendly Introductory Linear Regression
-Version: 0.8.0.9000
+Version: 0.8.0.9001
 Authors@R: c(
     person("Albert Y.", "Kim", email = "albert.ys.kim@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-7824-306X")),
     person("Chester", "Ismay", email = "chester.ismay@gmail.com", role = "aut", comment = c(ORCID = "0000-0003-2820-2547")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# moderndive 0.8.0.9001
+
+-   `View()` now renders correctly inside **webR** (the in-browser R that powers the ModernDive book's live exercises). webR has no pandoc, so a `DT::datatable()` htmlwidget cannot be saved as the self-contained HTML the cell needs (`DT::saveWidget()` errors), and the auto-print path is gated by `interactive()` being `FALSE`. In webR, `View()` now builds a self-contained static HTML table and pushes it through webR's viewer hook, so the data displays inline instead of only printing the explanatory message. Outside webR the `DT::datatable()` behaviour is unchanged.
+
 # moderndive 0.8.0.9000
 
 -   Fix issue [#58](https://github.com/moderndive/moderndive/issues/58)

--- a/R/view.R
+++ b/R/view.R
@@ -33,7 +33,9 @@
 #'
 #' @return In an interactive session, invisibly returns `NULL` (called for
 #'   the side effect of displaying `x` in a viewer). In a non-interactive
-#'   session, returns a [DT::datatable()] htmlwidget.
+#'   session, returns a [DT::datatable()] htmlwidget -- except inside webR
+#'   (where pandoc is unavailable), where it renders a self-contained static
+#'   HTML table through the browser viewer and invisibly returns `NULL`.
 #' @export
 #' @seealso [utils::View()], [DT::datatable()]
 #'
@@ -108,7 +110,85 @@ view_datatable <- function(x, title, n = 1000L, full = FALSE, seed = NULL,
       )
     )
   }
+  if (in_webr()) {
+    # webR has no pandoc, so a DT/htmlwidget cannot be saved as the
+    # self-contained HTML the cell needs (DT::saveWidget() errors), and the
+    # auto-print path is gated by interactive() == FALSE. Render a
+    # self-contained static HTML table and push it through webR's viewer hook,
+    # which quarto-webr turns into an inline iframe.
+    return(view_webr_table(x, title))
+  }
   DT::datatable(x, caption = title)
+}
+
+# TRUE when running inside webR (wasm R in the browser), where the DT path is
+# unavailable (no pandoc); see view_webr_table().
+in_webr <- function() {
+  nzchar(Sys.getenv("WEBR")) || identical(R.version$os, "emscripten")
+}
+
+# Render `x` as a self-contained static HTML table and hand it to webR's viewer
+# (installed by `webr::viewer_install()`), which emits a 'browse' message that
+# the quarto-webr cell renders in an iframe. Needs no pandoc / htmlwidget deps.
+view_webr_table <- function(x, title) {
+  viewer <- getOption("viewer")
+  if (!is.function(viewer)) {
+    return(DT::datatable(x, caption = title))  # no webR viewer hook; fall back
+  }
+  f <- tempfile(fileext = ".html")
+  writeLines(enc2utf8(webr_html_table(x, title)), f, useBytes = TRUE)
+  viewer(f)
+  invisible(NULL)
+}
+
+# Build a single self-contained HTML document: a scrollable, styled <table>
+# with inline CSS only (no external JS/CSS), so it renders inside the cell's
+# iframe verbatim.
+webr_html_table <- function(x, caption) {
+  x <- as.data.frame(x)
+  esc <- function(s) {
+    s <- gsub("&", "&amp;", s, fixed = TRUE)
+    s <- gsub("<", "&lt;", s, fixed = TRUE)
+    gsub(">", "&gt;", s, fixed = TRUE)
+  }
+  col_cells <- function(col) {
+    out <- if (is.numeric(col)) {
+      format(col, trim = TRUE, big.mark = ",", justify = "none")
+    } else {
+      as.character(col)
+    }
+    out[is.na(col)] <- "NA"
+    esc(out)
+  }
+  cols <- lapply(x, col_cells)
+  header <- paste0("<th>", esc(names(x)), "</th>", collapse = "")
+  rows <- vapply(seq_len(nrow(x)), function(i) {
+    cells <- paste0("<td>", vapply(cols, `[[`, character(1), i), "</td>",
+                    collapse = "")
+    paste0("<tr>", cells, "</tr>")
+  }, character(1))
+  style <- paste0(
+    "<style>",
+    "*{box-sizing:border-box}",
+    "body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;",
+    "margin:0;padding:0;color:#1b1b1b}",
+    ".md-cap{font-weight:600;padding:8px 10px 4px;font-size:14px}",
+    ".md-wrap{overflow:auto;max-height:460px;border:1px solid #e1e4e8;",
+    "border-radius:6px;margin:6px}",
+    "table{border-collapse:collapse;width:100%;font-size:13px}",
+    "thead th{position:sticky;top:0;background:#1F3A6B;color:#fff;",
+    "text-align:left;padding:6px 10px;white-space:nowrap}",
+    "tbody td{border-top:1px solid #eaecef;padding:4px 10px;white-space:nowrap}",
+    "tbody tr:nth-child(even){background:#f6f8fa}",
+    "</style>"
+  )
+  paste0(
+    "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">", style,
+    "</head><body><div class=\"md-cap\">", esc(caption), "</div>",
+    "<div class=\"md-wrap\"><table><thead><tr>", header,
+    "</tr></thead><tbody>", paste0(rows, collapse = ""),
+    "</tbody></table></div></body></html>"
+  )
 }
 
 # Draw `size` row indices from seq_len(n_rows) -- optionally reproducibly via

--- a/man/View.Rd
+++ b/man/View.Rd
@@ -30,7 +30,9 @@ sample is being shown. Default \code{FALSE}.}
 \value{
 In an interactive session, invisibly returns \code{NULL} (called for
 the side effect of displaying \code{x} in a viewer). In a non-interactive
-session, returns a \code{\link[DT:datatable]{DT::datatable()}} htmlwidget.
+session, returns a \code{\link[DT:datatable]{DT::datatable()}} htmlwidget -- except inside webR
+(where pandoc is unavailable), where it renders a self-contained static
+HTML table through the browser viewer and invisibly returns \code{NULL}.
 }
 \description{
 A drop-in replacement for \code{\link[utils:View]{utils::View()}}. In an interactive R session

--- a/tests/testthat/test-view.R
+++ b/tests/testthat/test-view.R
@@ -160,3 +160,45 @@ test_that("sample_rows() preserves RNG and honours seed", {
   b <- runif(1)
   expect_equal(a, b)
 })
+
+test_that("webr_html_table() builds a self-contained HTML table", {
+  html <- webr_html_table(head(mtcars, 3), "Data: mtcars")
+  expect_true(grepl("<table", html, fixed = TRUE))
+  expect_true(grepl("Data: mtcars", html, fixed = TRUE))
+  expect_true(grepl("<th>mpg</th>", html, fixed = TRUE))
+  # self-contained: no external scripts or resources
+  expect_false(grepl("<script", html, fixed = TRUE))
+  expect_false(grepl("src=", html, fixed = TRUE))
+  expect_false(grepl("href=", html, fixed = TRUE))
+  # HTML-special characters in cells are escaped
+  esc <- webr_html_table(data.frame(x = "a<b>&c", stringsAsFactors = FALSE), "t")
+  expect_true(grepl("a&lt;b&gt;&amp;c", esc, fixed = TRUE))
+})
+
+test_that("in webR, view_datatable() pushes a static table through the viewer", {
+  old_env <- Sys.getenv("WEBR", unset = NA)
+  old_viewer <- getOption("viewer")
+  Sys.setenv(WEBR = "1")
+  on.exit({
+    if (is.na(old_env)) Sys.unsetenv("WEBR") else Sys.setenv(WEBR = old_env)
+    options(viewer = old_viewer)
+  }, add = TRUE)
+  pushed <- NULL
+  options(viewer = function(url, ...) pushed <<- url)
+  out <- view_datatable(head(mtcars, 3), "Data: mtcars")
+  expect_null(out)
+  expect_true(!is.null(pushed) && file.exists(pushed))
+  expect_true(grepl("<table",
+                    paste(readLines(pushed), collapse = ""), fixed = TRUE))
+})
+
+test_that("outside webR, view_datatable() still returns a DT widget", {
+  skip_if_not_installed("DT")
+  old_env <- Sys.getenv("WEBR", unset = NA)
+  Sys.setenv(WEBR = "")
+  on.exit(
+    if (is.na(old_env)) Sys.unsetenv("WEBR") else Sys.setenv(WEBR = old_env),
+    add = TRUE
+  )
+  expect_s3_class(view_datatable(head(mtcars, 3), "x"), "datatables")
+})


### PR DESCRIPTION
## Problem

In the ModernDive book's in-browser (webR) exercises, `moderndive::View(olympic_athletes)` prints only its explanatory message — the table never appears.

## Root cause (confirmed by running webR 0.6.0 / R 4.6.0 in Node)

Two layers, both required for a DT widget to display, both unavailable in webR:
1. **No pandoc** — `DT::saveWidget(selfcontained = TRUE)` errors ("Saving a widget with selfcontained = TRUE requires pandoc"), and the cell's iframe needs self-contained HTML.
2. **`interactive()` is `FALSE`** — `htmlwidgets:::print.htmlwidget(x, ..., view = interactive())` short-circuits, so the auto-printed widget is never handed to webR's viewer hook.

(quarto-webr renders htmlwidgets by having `webr::viewer_install()`'s viewer write a `browse` message that becomes an iframe — but the widget never gets that far.)

## Fix

In webR (`Sys.getenv("WEBR")` / `R.version$os == "emscripten"`), `View()` builds a **self-contained static HTML table** (base R + inline CSS, no JS, no pandoc) and pushes it straight through the viewer hook, which quarto-webr renders in an iframe. Outside webR, `DT::datatable()` behaviour is unchanged. Sampling/`n`/`full`/`seed`/`quiet` still apply.

Verified end-to-end in webR 0.6.0; adds tests for the webR path (16/16 view tests pass).

Merging this triggers the moderndive r-universe wasm rebuild that the book's webR pulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)